### PR TITLE
fix smart panel compiling issue on MCUXpresso 11.8.0

### DIFF
--- a/home_panel/cm7/freertos/libraries/3rdparty/tinycbor/src/cborpretty.c
+++ b/home_panel/cm7/freertos/libraries/3rdparty/tinycbor/src/cborpretty.c
@@ -33,6 +33,7 @@
 #include "compilersupport_p.h"
 #include "utf8_p.h"
 
+#include <sys/types.h>
 #include <inttypes.h>
 #include <string.h>
 


### PR DESCRIPTION
fix compiling issue with
freertos/libraries/3rdparty/tinycbor/src/cborpretty.c